### PR TITLE
fix: dev environment exception on Windows

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ const os = require("os");
 const { app, BrowserWindow } = require("electron");
 const autoUpdate = require("update-electron-app");
 const debug = require("electron-debug");
+const isDev = require('electron-is-dev');
 
 debug({ showDevTools: false });
 
@@ -13,7 +14,7 @@ if (require("electron-squirrel-startup")) {
   app.quit();
 }
 
-if (os.platform() === "win32") {
+if (os.platform() === "win32" && !isDev) {
   autoUpdate();
 }
 


### PR DESCRIPTION
Auto update was preventing the development electron client from launching on Windows, added a check to disable autoupdate in development.